### PR TITLE
chore: migrate-to-sepolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/0708f99a-542e-416d-83ce-4ae4f11e9b79/deploy-status)](https://app.netlify.com/sites/centralizedarbitrator/deploys)
 
-Supported netwoks: Mainnet, Kovan, Ropsten, Rinkeby, Goerli.
+Supported netwoks: Mainnet, Sepolia.

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -15,14 +15,10 @@ import { NotificationType } from "../types"
 
 const NETWORKS = {
   1: "mainnet",
-  3: "ropsten",
-  4: "rinkeby",
-  5: "goerli",
-  42: "kovan",
+  11155111: "sepolia",
 } as unknown as string[]
 
 const Dashboard = () => {
-
   const [archon, setArchon] = useState({})
   const [uglyFixtoBug13, setUglyFixtoBug13] = useState("") // See https://github.com/kleros/centralized-arbitrator-dashboard/issues/13
   const [networkType, setNetworkType] = useState("")
@@ -36,14 +32,8 @@ const Dashboard = () => {
     switch (networkType) {
       case "mainnet":
         return " "
-      case "kovan":
-        return "kovan."
-      case "ropsten":
-        return "ropsten."
-      case "goerli":
-        return "goerli."
-      case "rinkeby":
-        return "rinkeby."
+      case "sepolia":
+        return "sepolia."
       default:
         return " "
     }
@@ -63,7 +53,6 @@ const Dashboard = () => {
       })
 
       web3.eth.net.getNetworkType((_error, networkTypeGet) => {
-        
         setNetworkType(networkTypeGet == "main" ? "mainnet" : networkTypeGet)
         setWallet(accounts[0].toLowerCase())
         if (lscache.get(accounts[0]))
@@ -87,7 +76,7 @@ const Dashboard = () => {
     })
 
     window.ethereum.on("chainChanged", (networkId: string) => {
-      setNetworkType(NETWORKS[web3.utils.hexToNumber(networkId)])
+      setNetworkType(NETWORKS[web3.utils.hexToNumber(networkId) as number])
       setSelectedAddress("")
     })
   }, [])

--- a/src/components/Dispute.tsx
+++ b/src/components/Dispute.tsx
@@ -4,7 +4,11 @@ import Archon from "@kleros/archon"
 import { FC, useEffect, useState } from "react"
 import web3 from "../ethereum/web3"
 import { Contract } from "ethers"
-import { MetaevidenceObject, ReturnEvidence, ReturnMetaevidence } from "../types"
+import {
+  MetaevidenceObject,
+  ReturnEvidence,
+  ReturnMetaevidence,
+} from "../types"
 //import { arbitrableInstanceAt } from "../ethereum/arbitrable"
 import { getReadOnlyRpcUrl } from "../ethereum/web3"
 import { EvidenceType } from "../types"
@@ -62,6 +66,12 @@ const Dispute: FC<{
           .then((evidences: EvidenceType[]) => {
             setEvidenceArrayState(evidences)
           })
+          .catch((err: Error) => {
+            console.log("error getting evidences", { id: p.id, error: err })
+          })
+      })
+      .catch((err: Error) => {
+        console.log("error getting disputes", { id: p.id, error: err })
       })
   }
 
@@ -85,6 +95,12 @@ const Dispute: FC<{
           .then((x: MetaevidenceObject) => {
             setMetaevidenceState(x)
           })
+          .catch((err: Error) => {
+            console.log("Error getting metaevidence", err)
+          })
+      })
+      .catch((err: Error) => {
+        console.log("Error getting dispute", err)
       })
   }
 
@@ -143,14 +159,8 @@ const Dispute: FC<{
     switch (networkType) {
       case "mainnet":
         return " "
-      case "kovan":
-        return "kovan."
-      case "ropsten":
-        return "ropsten."
-      case "goerli":
-        return "goerli."
-      case "rinkeby":
-        return "rinkeby."
+      case "sepolia":
+        return "sepolia."
       default:
         return " "
     }

--- a/src/components/Evidence.tsx
+++ b/src/components/Evidence.tsx
@@ -13,7 +13,7 @@ const Evidence: FC<{
     }
     return (
       <a
-        href={p.ipfsGateway + p.evidence.evidenceJSON.fileURI}
+        href={p.ipfsGateway + p.evidence.evidenceJSON?.fileURI}
         rel="noopener noreferrer"
         target="_blank"
         style={{ fontSize: "0.8em" }}
@@ -26,9 +26,9 @@ const Evidence: FC<{
   return (
     <div style={{ fontSize: "0.6em" }}>
       <br></br>
-      <strong>• {p.evidence.evidenceJSON.title}</strong> {showOptions()}
+      <strong>• {p.evidence.evidenceJSON?.name}</strong> {showOptions()}
       <br></br>
-      {p.evidence.evidenceJSON.description}
+      {p.evidence.evidenceJSON?.description}
       <br></br>
       <br></br>
     </div>

--- a/src/ethereum/web3.ts
+++ b/src/ethereum/web3.ts
@@ -36,11 +36,7 @@ export default web3
 
 const chainIdToRpcEndpoint = {
   1: "https://mainnet.infura.io/v3/" + INFURA_ID,
-  3: "https://ropsten.infura.io/v3/" + INFURA_ID,
-  4: "https://rinkeby.infura.io/v3/" + INFURA_ID,
-  5: "https://goerli.infura.io/v3/" + INFURA_ID,
-  42: "https://kovan.infura.io/v3/" + INFURA_ID,
-  77: "https://sokol.poa.network",
+  11155111: "https://sepolia.infura.io/v3/" + INFURA_ID,
   100: "https://rpc.gnosischain.com",
 }
 


### PR DESCRIPTION
closes #48 

- Migrate to `sepolia`
- Fix Crashing errors
- Remove support for `goerli`, `rinkeby`, `ropsten`, `kovan`